### PR TITLE
Bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ taggd>=0.3.1
 HTSeq>=0.7.1
 pysam>=0.7.4
 setuptools
+pympler

--- a/stpipeline/common/unique_events_parser.pyx
+++ b/stpipeline/common/unique_events_parser.pyx
@@ -152,9 +152,6 @@ class uniqueEventsParser():
                                "Missing attributes for record {}\n".format(clear_name))
                 continue
 
-            # Skip reads that don't get a gene from HtSeq This should probably be handled in a nicer way later on!!
-            if gene == "__no_feature": continue
-
             # Create a new transcript and add it to the in memory gene_buffer dictionary
             transcript = (chrom, start, end, clear_name, mapping_quality, strand, umi)
             spot_coordinates = (x,y)
@@ -384,6 +381,9 @@ class geneBuffer():
         # For each gene in the buffer
         if empty and self.verbose: self.print_stats()
         for gene in _tmp:
+            
+            # fix to include any "__no_feature" annotations
+            if gene == '__no_feature' and not empty: continue
 
             # check if the current position is past the gene end coordinate
             if empty \


### PR DESCRIPTION
Found that the pipeline_run_test.py failed for my latest commit.

This was due to that __no_feature annotated reads were not handled correctly,
if the "--include-non-annotated" option was specified they were still not included even though they should have been.

The bug is now been fixed and pipeline_run_test.py finishes successfully.

Also added pympler to the requirements list as its needed for writing a debug message even though it is seldom used.