### PR TITLE
fixing the sam/bam format

### DIFF
--- a/stpipeline/common/fastq_utils.py
+++ b/stpipeline/common/fastq_utils.py
@@ -250,7 +250,10 @@ def filterInputReads(fw,
     keep_discarded_files = out_rv_discarded is not None
     
     # Create output file writers
-    bam_header = { 'HD': {'VN': '1', 'SO':'unsorted'} }
+    bam_header = {
+            'HD': {'VN': '1.5', 'SO':'unsorted'},
+            'RG': [{'ID': '0', 'SM' : 'unknown_sample', 'PL' : 'ILLUMINA' }]
+        }
     bam_file = pysam.AlignmentFile(out_rv, "wb", header=bam_header)
     if keep_discarded_files:
         out_rv_handle_discarded = safeOpenFile(out_rv_discarded, 'w')

--- a/stpipeline/common/sam_utils.py
+++ b/stpipeline/common/sam_utils.py
@@ -9,7 +9,7 @@ def convert_to_AlignedSegment(header, sequence, quality,
     """
     This function converts the input variables 
     (header,sequence,quality,barcode_sequence,umi_sequence)
-    to a pysam.AlignedSegment with the umi and barcode 
+    to a unaligned pysam.AlignedSegment with the umi and barcode 
     informations as the following tags:
         Tag  Value
         "B0" barcode_sequence
@@ -30,8 +30,12 @@ def convert_to_AlignedSegment(header, sequence, quality,
     aligned_segment.query_sequence = sequence
     aligned_segment.query_qualities = quality
 
+    # setting the flag to un_mapped
+    aligned_segment.flag |= pysam.FUNMAP
+
     # Set the tags
     aligned_segment.set_tag('B0', barcode_sequence)
     aligned_segment.set_tag('B3', umi_sequence)
+    aligned_segment.set_tag('RG', '0')
 
     return aligned_segment


### PR DESCRIPTION
Right this fixes the format still I don't think it makes much of a difference in the end

the 'RG' tag in the header section is required by the picardtools validation tool

though not marked as required in the samtools specification https://github.com/samtools/hts-specs/

anyway fixed and validation now finds no errors