### PR TITLE
add temp folder to samtools sort

### DIFF
--- a/stpipeline/core/pipeline.py
+++ b/stpipeline/core/pipeline.py
@@ -844,10 +844,11 @@ class Pipeline():
                                       FILENAMES["demultiplexed_prefix"], # Prefix for output files
                                       self.keep_discarded_files)
                 # TaggD does not output the BAM file sorted
-                command = "samtools sort -T sort_bam -@ {} -o {} {}".format(self.threads,
+                command = "samtools sort -T {}/sort_bam -@ {} -o {} {}".format(self.temp_folder,
+                                                                            self.threads,
                                                                             FILENAMES["demultiplexed_matched"],
                                                                             FILENAMES["demultiplexed_matched"])
-                subprocess.check_call(command, shell=True) 
+                subprocess.check_call(command, shell=True)
             except Exception:
                 raise 
         


### PR DESCRIPTION
The temp folder was missing from the temp output prefix in the `samtools sort` call.  This led to crashes when multiple instances overwrote each other.