### PR TITLE
cython python3 directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# cythonized files
+stpipeline/common/*.c
+
 # Distribution / packaging
 .Python
 env/

--- a/stpipeline/common/cdistance.pyx
+++ b/stpipeline/common/cdistance.pyx
@@ -1,3 +1,5 @@
+#cython: language_level=3
+
 cpdef int hamming_distance(a, b):
     cdef char * aa = a
     cdef char * bb = b

--- a/stpipeline/common/filterInputReads.pyx
+++ b/stpipeline/common/filterInputReads.pyx
@@ -1,3 +1,5 @@
+#cython: language_level=3
+
 import sys
 import os
 import re

--- a/stpipeline/common/unique_events_parser.pyx
+++ b/stpipeline/common/unique_events_parser.pyx
@@ -1,3 +1,5 @@
+#cython: language_level=3
+
 import os
 import sys
 import time


### PR DESCRIPTION
Added directives to the `stpipeline/common/*.pyx` files.  Without the directives, the following warning is printed for each file when the program is compiled:
```
FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release!
```
Also, the cythonized files were added to `.gitignore`.